### PR TITLE
Potential fix for code scanning alert no. 48: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "tweetnacl": "file:./src/tweetnacl",
     "ulimit": "0.0.2",
     "ws": "^8.17.1",
-    "x2js": "^3.4.4"
+    "x2js": "^3.4.4",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.0",

--- a/www/pad/comments.js
+++ b/www/pad/comments.js
@@ -4,6 +4,7 @@
 
 define([
     'jquery',
+    'sanitize-html',
     'json.sortify',
     '/common/common-util.js',
     '/common/common-hash.js',
@@ -11,7 +12,7 @@ define([
     '/common/common-interface.js',
     '/common/common-ui-elements.js',
     '/customize/messages.js'
-], function($, Sortify, Util, Hash, h, UI, UIElements, Messages) {
+], function($, Sortify, Util, Hash, h, UI, UIElements, Messages, sanitizeHtml) {
     var Comments = {};
 
     /*
@@ -115,7 +116,7 @@ define([
             var data = others[id];
             Env.common.mailbox.sendTo("COMMENT_REPLY", {
                 channel: privateData.channel,
-                comment: data.comment.replace(/<[^>]*>/g, ''),
+                comment: sanitizeHtml(data.comment),
                 content: data.content
             }, {
                 channel: data.notifications,


### PR DESCRIPTION
Potential fix for [https://github.com/DiogoAlexandreOliveiraDaSilva/SES/security/code-scanning/48](https://github.com/DiogoAlexandreOliveiraDaSilva/SES/security/code-scanning/48)

To fix the issue, the sanitization logic should be updated to ensure that all unsafe HTML tags and content are removed. This can be achieved by applying the regular expression replacement repeatedly until no more replacements can be performed, or by using a well-tested library like `sanitize-html` to handle sanitization comprehensively.

The best approach here is to use the `sanitize-html` library, as it is specifically designed to handle HTML sanitization and ensures that all unsafe tags and attributes are removed. This approach is robust, avoids reinventing the wheel, and handles edge cases effectively.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
